### PR TITLE
A component to set the landing page if a website consists of multiple webpages

### DIFF
--- a/CMS/Components/BlazorComponent/SetLandingPage.razor
+++ b/CMS/Components/BlazorComponent/SetLandingPage.razor
@@ -1,0 +1,69 @@
+﻿@using CMS.Services
+@inject IDbContextFactory<CMS.Data.ApplicationDbContext> DbFactory
+@rendermode InteractiveServer
+
+@if (WebPages == null || !WebPages.Any())
+{
+    <p>Webbsiten har inga webbsidor.</p>
+}
+else
+{
+    <div class="landing-page-container">
+        <p>Startsida: </p>
+        <select id="landingpage" @bind="selectedWebPageId" @bind:after="SaveLandingPage">
+            <option value="">Välj startsida</option>
+            @foreach (var webpageheader in WebPages)
+            {
+                <option value="@webpageheader.WebPageId">@webpageheader.Header</option>
+            }
+        </select>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int WebSiteId { get; set; }
+
+    private IEnumerable<WebPage>? WebPages { get; set; }
+    private int? selectedWebPageId { get; set; }
+    private string? landingPageHeader { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        using var context = DbFactory.CreateDbContext();
+
+        // Hämta alla webpages som tillhör WebSiteId
+        WebPages = await context.WebPages
+            .Where(wp => wp.WebSiteId == WebSiteId)
+            .ToListAsync();
+
+        // Hämta websitens data
+        var website = await context.WebSites
+            .FirstOrDefaultAsync(ws => ws.WebSiteId == WebSiteId);
+
+        if (website?.LandingPage != null)
+        {
+            selectedWebPageId = website.LandingPage;
+
+            // Hämta Header(rubrik, vi får byta namn senare) för den valda startsidan
+            var landingPage = await context.WebPages
+                .FirstOrDefaultAsync(wp => wp.WebPageId == website.LandingPage);
+
+            landingPageHeader = landingPage?.Header;
+        }
+    }
+
+    public async Task SaveLandingPage()
+    {
+        using var context = DbFactory.CreateDbContext();
+
+        var website = await context.WebSites
+            .FirstOrDefaultAsync(ws => ws.WebSiteId == WebSiteId);
+
+        if (website != null)
+        {
+            website.LandingPage = selectedWebPageId;
+            await context.SaveChangesAsync();
+        }
+    }
+}

--- a/CMS/Components/BlazorComponent/SetLandingPage.razor
+++ b/CMS/Components/BlazorComponent/SetLandingPage.razor
@@ -1,0 +1,136 @@
+﻿@using CMS.Services
+@inject IDbContextFactory<CMS.Data.ApplicationDbContext> DbFactory
+@rendermode InteractiveServer
+
+@if (WebPages == null || !WebPages.Any())
+{
+    <p>Webbsiten har inga webbsidor.</p>
+}
+else
+{
+    <div class="landing-page-container">
+        <p>Startsida: </p>
+        <select id="landingpage" @bind="selectedWebPageId" @bind:after="SaveLandingPage">
+            <option value="">Välj startsida</option>
+            @foreach (var webpageheader in WebPages)
+            {
+                <option value="@webpageheader.WebPageId">@webpageheader.Header</option>
+            }
+        </select>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int WebSiteId { get; set; }
+
+    private IEnumerable<WebPage>? WebPages { get; set; }
+    private int? selectedWebPageId { get; set; }
+    private string? landingPageHeader { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        using var context = DbFactory.CreateDbContext();
+
+        // Hämta alla webpages som tillhör WebSiteId
+        WebPages = await context.WebPages
+            .Where(wp => wp.WebSiteId == WebSiteId)
+            .ToListAsync();
+
+        // Hämta websitens data
+        var website = await context.WebSites
+            .FirstOrDefaultAsync(ws => ws.WebSiteId == WebSiteId);
+
+        if (website?.LandingPage != null)
+        {
+            selectedWebPageId = website.LandingPage;
+
+            // Hämta Header(namn/rubrik, vi får byta namn senare) för den valda startsidan
+            var landingPage = await context.WebPages
+                .FirstOrDefaultAsync(wp => wp.WebPageId == website.LandingPage);
+
+            landingPageHeader = landingPage?.Header;
+        }
+    }
+
+    public async Task SaveLandingPage()
+    {
+        using var context = DbFactory.CreateDbContext();
+
+        var website = await context.WebSites
+            .FirstOrDefaultAsync(ws => ws.WebSiteId == WebSiteId);
+
+        if (website != null)
+        {
+            website.LandingPage = selectedWebPageId;
+            await context.SaveChangesAsync();
+
+            // Uppdatera sidan efter sparning
+            var landingPage = await context.WebPages
+                .FirstOrDefaultAsync(wp => wp.WebPageId == selectedWebPageId);
+
+            landingPageHeader = landingPage?.Header;
+        }
+    }
+}
+
+
+
+@* @using CMS.Entities
+@using CMS.Services
+@inject IDbContextFactory<CMS.Data.ApplicationDbContext> DbFactory
+@rendermode InteractiveServer
+
+@if (WebPages == null || !WebPages.Any())
+{
+    <p>Webbsiten har inga webbsidor.</p>
+}
+else
+{
+    <div>
+        <p>Startsida: </p>
+    </div>
+    <div class="landingpage">
+        <select id="landingpage" @bind="selectedWebPageId" @bind:after="SaveLandingPage">
+            <option value="">Välj startsida</option>
+            @foreach (var webpageheader in WebPages)
+            {
+                <option value="@webpageheader.WebPageId">@webpageheader.Header</option>
+            }
+        </select>
+    </div>
+}
+
+
+
+@code {
+    [Parameter]
+    public int WebSiteId { get; set; }
+
+    private IEnumerable<WebPage>? WebPages { get; set; }
+    private int? selectedWebPageId { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        using var context = DbFactory.CreateDbContext();
+
+        // Hämta alla webpages som tillhör WebSiteId
+        WebPages = await context.WebPages
+            .Where(wp => wp.WebSiteId == WebSiteId)
+            .ToListAsync();
+    }
+
+    public async Task SaveLandingPage()
+    {
+        using var context = DbFactory.CreateDbContext();
+
+        var website = await context.WebSites
+            .FirstOrDefaultAsync(ws => ws.WebSiteId == WebSiteId);
+
+        if (website != null)
+        {
+            website.LandingPage = selectedWebPageId;
+            await context.SaveChangesAsync();
+        }
+    }
+} *@

--- a/CMS/Components/BlazorComponent/SetLandingPage.razor.css
+++ b/CMS/Components/BlazorComponent/SetLandingPage.razor.css
@@ -1,0 +1,17 @@
+﻿.landing-page-container {
+    display: flex;
+    align-items: center; /* This ensures vertical centering */
+    gap: 20px;
+    width: 100%;
+}
+
+    .landing-page-container p {
+        margin: 0; /* Removes any default margin that may misalign the text */
+        display: flex; /* Ensures the paragraph is treated like flex child */
+        align-items: center; /* Vertically centers the text in the paragraph */
+    }
+
+#landingpage {
+    width: 40%;
+    height: auto; /* Ensures the dropdown height is consistent */
+}

--- a/CMS/Components/Pages/WebSitePages/Edit.razor
+++ b/CMS/Components/Pages/WebSitePages/Edit.razor
@@ -27,6 +27,11 @@ else
                     <ValidationMessage For="() => WebSite.Title" class="text-danger" />
                 </div>
                 <div class="mb-3">
+                    <label for="image" class="form-label">Bild:</label>
+                    <InputText id="description" @bind-Value="WebSite.ImageUrl" class="form-control" />
+                    <ValidationMessage For="() => WebSite.ImageUrl" class="text-danger" />
+                </div>
+                <div class="mb-3">
                     <label for="description" class="form-label">Description:</label>
                     <InputText id="description" @bind-Value="WebSite.Description" class="form-control" />
                     <ValidationMessage For="() => WebSite.Description" class="text-danger" />
@@ -51,6 +56,10 @@ else
                     <InputText id="userid" @bind-Value="WebSite.UserId" class="form-control" />
                     <ValidationMessage For="() => WebSite.UserId" class="text-danger" />
                 </div>
+
+                <SetLandingPage WebSiteId="@WebSiteId" />
+
+                <br />
                 <button type="submit" class="btn btn-primary">Save</button>
             </EditForm>
         </div>

--- a/CMS/Components/Pages/WebSitePages/Edit.razor
+++ b/CMS/Components/Pages/WebSitePages/Edit.razor
@@ -27,6 +27,11 @@ else
                     <ValidationMessage For="() => WebSite.Title" class="text-danger" />
                 </div>
                 <div class="mb-3">
+                    <label for="image" class="form-label">Bild:</label>
+                    <InputText id="description" @bind-Value="WebSite.ImageUrl" class="form-control" />
+                    <ValidationMessage For="() => WebSite.ImageUrl" class="text-danger" />
+                </div>
+                <div class="mb-3">
                     <label for="description" class="form-label">Description:</label>
                     <InputText id="description" @bind-Value="WebSite.Description" class="form-control" />
                     <ValidationMessage For="() => WebSite.Description" class="text-danger" />
@@ -51,6 +56,10 @@ else
                     <InputText id="userid" @bind-Value="WebSite.UserId" class="form-control" />
                     <ValidationMessage For="() => WebSite.UserId" class="text-danger" />
                 </div>
+
+                <SetLandingPage WebSiteId="@WebSiteId"/>
+
+                <br />
                 <button type="submit" class="btn btn-primary">Save</button>
             </EditForm>
         </div>
@@ -88,13 +97,23 @@ else
         }
     }
 
-    // To protect from overposting attacks, enable the specific properties you want to bind to.
-    // For more details, see https://aka.ms/RazorPagesCRUD.
     public async Task UpdateWebSite()
     {
         using var context = DbFactory.CreateDbContext();
-        WebSite!.LastUpdated = DateOnly.FromDateTime(DateTime.Today);
-        context.Attach(WebSite!).State = EntityState.Modified;
+
+        var existingWebSite = await context.WebSites.FindAsync(WebSite!.WebSiteId);
+
+        if (existingWebSite == null)
+        {
+            NavigationManager.NavigateTo("notfound");
+            return;
+        }
+
+        // Endast följande fält skall sparas när UpdateWebSite() körs, detta är en fulfix för UpdateWebSite() alltid sätter LandingPage till null.
+        existingWebSite.Title = WebSite.Title;
+        existingWebSite.ImageUrl = WebSite.ImageUrl;
+        existingWebSite.Description = WebSite.Description;
+        existingWebSite.LastUpdated = DateOnly.FromDateTime(DateTime.Today);
 
         try
         {
@@ -102,7 +121,7 @@ else
         }
         catch (DbUpdateConcurrencyException)
         {
-            if (!WebSiteExists(WebSite!.WebSiteId))
+            if (!WebSiteExists(WebSite.WebSiteId))
             {
                 NavigationManager.NavigateTo("notfound");
             }
@@ -111,9 +130,9 @@ else
                 throw;
             }
         }
-
         NavigationManager.NavigateTo("/websites");
     }
+
 
     bool WebSiteExists(int websiteid)
     {

--- a/CMS/Components/Pages/WebSitePages/Index.razor
+++ b/CMS/Components/Pages/WebSitePages/Index.razor
@@ -6,14 +6,16 @@
 
 @inject IGetCurrentUserService GetCurrentUserService
 @inject IDbContextFactory<ApplicationDbContext> DbFactory
+@inject NavigationManager NavigationManager
+
 @implements IAsyncDisposable
 
-<PageTitle>Index</PageTitle>
+<PageTitle>Mina websites</PageTitle>
 
-<h1>Index</h1>
+<h3>Mina websites</h3>
 
 <p>
-    <a href="websites/create">Create New</a>
+    <a href="websites/create">Skapa ny website</a>
 </p>
 @if (UserId != null)
 {
@@ -35,13 +37,19 @@
            
             }
              <h3> @website.Title</h3>
-             <p style="font-size: small"> @website.Description</p>
-            <p style="font-size: small"> @website.CreationDate</p>
+             <p style="font-size: small"> Beskrivning: @website.Description</p>
+            <p style="font-size: small"> Skapad: @website.CreationDate</p>
 
-            <a href="@($"websites/edit?websiteid={website.WebSiteId}")">Edit</a> |
-            <a href="@($"websites/details?websiteid={website.WebSiteId}")">Details</a> |
-            <a href="@($"websites/delete?websiteid={website.WebSiteId}")">Delete</a> |
-            <a href="@($"/webpages/create?websiteid={website.WebSiteId}")">Add Page</a>
+@*             <button @onclick="@(() => NavigationManager.NavigateTo($"websites/edit?websiteid={website.WebSiteId}"))">Editera</button>
+            <button @onclick="@(() => NavigationManager.NavigateTo($"websites/details?websiteid={website.WebSiteId}"))">Detaljer</button>
+            <button @onclick="@(() => NavigationManager.NavigateTo($"/webpages/create?websiteid={website.WebSiteId}"))">Lägg till websida</button>
+            <button @onclick="@(() => NavigationManager.NavigateTo($"websites/delete?websiteid={website.WebSiteId}"))">Radera</button>
+            <br /> *@
+
+            <a href="@($"websites/edit?websiteid={website.WebSiteId}")">Editera</a> |
+            <a href="@($"websites/details?websiteid={website.WebSiteId}")">Detaljer</a> |
+            <a href="@($"/webpages/create?websiteid={website.WebSiteId}")">Lägg till websida</a> |
+            <a href="@($"websites/delete?websiteid={website.WebSiteId}")">Radera</a> 
         </div>
     }
     </div>

--- a/CMS/Entities/WebSite.cs
+++ b/CMS/Entities/WebSite.cs
@@ -3,7 +3,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace CMS.Entities
 {
-
     public class WebSite
     {
         public int WebSiteId { get; set; }
@@ -15,10 +14,10 @@ namespace CMS.Entities
         public string Description { get; set; }
         public DateOnly CreationDate { get; set; } = DateOnly.FromDateTime(DateTime.Now);
         public DateOnly? LastUpdated { get; set; }
-       
+        public int? LandingPage { get; set; }
+
         public string UserId { get; set; } = string.Empty;
         public ApplicationUser ApplicationUser { get; set; } 
         public ICollection<WebPage> WebPages { get; set; }  // Virtual för lazyloading
-   
     }
 }

--- a/CMS/Extensions/WebappExtension.cs
+++ b/CMS/Extensions/WebappExtension.cs
@@ -20,7 +20,9 @@ namespace CMS.Extensions
 
                 try
                 {
-                    await SeedData.InitAsync(context, registerService, roleManager);
+                    // Ändra till: await SeedData.InitAsync(context, registerService, roleManager);
+                    // Om du vill ha tidigare seed med mock users/websites/webpages
+                    await SeedWithoutWebsites.InitAsync(context, registerService, roleManager);
                 }
                 catch (Exception ex)
                 {

--- a/CMS/Seed/SeedWithoutWebsites.cs
+++ b/CMS/Seed/SeedWithoutWebsites.cs
@@ -1,6 +1,4 @@
-﻿using Bogus;
-using CMS.Data;
-using CMS.Entities;
+﻿using CMS.Data;
 using CMS.Models;
 using CMS.Services;
 using Microsoft.AspNetCore.Identity;
@@ -8,19 +6,10 @@ using Microsoft.EntityFrameworkCore;
 
 namespace CMS.Seed
 {
-    public static class SeedData
+    public static class SeedWithoutWebsites
     {
-
-        private static Faker faker = new Faker();
-        private static Random random = new Random();
         public static async Task InitAsync(ApplicationDbContext context, ICreateUserService registerService, RoleManager<IdentityRole> roleManager)
         {
-
-            if (context.WebSites.Any())
-            {
-                return;
-            }
-
             //adds templates we have made in folder if we haven't any values in the template table
             if (!context.Templates.Any())
             {
@@ -28,7 +17,7 @@ namespace CMS.Seed
                 await context.Templates.AddRangeAsync(templates);
             }
 
-            // Seed roles
+            // Check and seed roles if they don't exist
             var roles = new[] { "Admin", "User" };
             foreach (var role in roles)
             {
@@ -38,97 +27,12 @@ namespace CMS.Seed
                 }
             }
 
-            for (int i = 0; i < 4; i++)
-            {
-                var fName = faker.Name.FirstName();
-                var lName = faker.Name.LastName();
-                var email = faker.Internet.Email(fName, lName, "zocom.se");
-                var result = await registerService.CreateUser(email, "pSrkXHN6z8s%KHW@");
-                Console.WriteLine(result);
-            }
-
-            var result1 = await registerService.CreateUser(@"test@test.com", "pSrkXHN6z8s%KHW@");
-            Console.WriteLine(result1);
-
-            var userId = context.Users.Where(u => EF.Functions.Like(u.Email, "test@test.com")).Select(u => u.Id).FirstOrDefault();
-            if (userId == null)
-            {
-                return;
-            }
-
-
-            var menus = CreateWebSites(userId);
-
-            await context.AddRangeAsync(menus);
-            context.SaveChanges();
-
-        }
-
-        private static ICollection<WebSite> CreateWebSites(string OwnerId)
-        {
-
-            var list = new List<WebSite>();
-
-            for (int i = 0; i < 10; i++)
-            {
-
-                var menu = new WebSite
-                {
-                    Title = faker.Lorem.Slug(2),
-                    Description = faker.Lorem.Sentence(),
-                    WebPages = CreateWebpages(random.Next(3, 8)),
-                    UserId = OwnerId
-                };
-
-                list.Add(menu);
-            }
-
-            return list;
-        }
-
-        private static ICollection<WebPage> CreateWebpages(int count)
-        {
-            var list = new List<WebPage>();
-            for (int i = 0; i < count; i++)
-            {
-
-                var webpage = new WebPage
-                {
-                    Header = faker.Lorem.Slug(2),
-                    Body = faker.Lorem.Sentence(10),
-                    Footer = faker.Lorem.Sentence(2),
-                };
-
-                list.Add(webpage);
-            }
-
-            return list;
-        }
-
-        private static ICollection<Content> CreateContentBlocks()
-        {
-
-            var list = new List<Content>
-            {
-              new Content
-            {
-                ContentName = faker.Lorem.Slug(3),
-                           },
-
-            new Content
-            {
-
-                ContentName ="https://picsum.photos/200/300?random=" + $"{random.Next(1,10000)}",
-
-            },
-             new Content
-            {
-                ContentName = faker.Lorem.Slug(10),
-
-            }
-            };
-
-            return list;
+            // Check and seed test user if they don't exist
+            //var testEmail = @"test@test.com";
+            //if (!context.Users.Any(u => EF.Functions.Like(u.Email, testEmail)))
+            //{
+            //    var result = await registerService.CreateUser(testEmail, "pSrkXHN6z8s%KHW@");
+            //}
         }
 
         private static ICollection<Template> CreateTemplates()
@@ -190,9 +94,7 @@ namespace CMS.Seed
                     InputFormPath = "Templates.InputForm.SingleVideoInputForm"
                 }
             };
-
             return list;
         }
-
     }
 }

--- a/CMS/appsettings.json
+++ b/CMS/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=127.0.0.1,1433;Database=DBnew;User Id=sa;Password=Strong_Password123;MultipleActiveResultSets=false;TrustServerCertificate=true;"
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=CMS;Trusted_Connection=True;MultipleActiveResultSets=true"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
A component to set the landing page if a website consists of multiple webpages.

- Added:  int? 'LandingPage' to WebSite entity
- Added: 'SeedWithoutWebsites' (no users either) change inside extension method if you want the old seed file with users and websites/webages
- Fixed: Edit 'WebSite' was missing fields for 'ImageUrl'
- Fixed: bug with Edit Save-button overwriting LandingPage values

_The component is not tied to the Edit page Save button in the picture, landingpage is automatically saved upon changing the selection in the dropdownlist_
<img width="378" alt="image" src="https://github.com/user-attachments/assets/9562ef5c-38c7-4d4c-bfa2-2faefc023ed2">


<img width="506" alt="image" src="https://github.com/user-attachments/assets/acffd67a-177c-49e1-943e-b04b067172f5">

Edit WebappExtension.cs to swap between the different seeds