### PR TITLE
added simple texteditor template and adding save all content button in create multiple pages 

### DIFF
--- a/CMS/CMS.csproj
+++ b/CMS/CMS.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>

--- a/CMS/Components/App.razor
+++ b/CMS/Components/App.razor
@@ -13,9 +13,6 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"rel="stylesheet">
     <link href="/_content/PSC.Blazor.Components.MarkdownEditor/css/easymde.min.css" rel="stylesheet" />
 
-    <!-- Quill CSS -->
-    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
-
     <HeadOutlet/>
 </head>
 
@@ -29,21 +26,6 @@
 <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js"></script>
 <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/markdownEditor.js"></script>
 
-<!-- Quill JS -->
-<script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
- <script>
-        let quill;
-
-        function initQuillEditor() {
-            quill = new Quill('#quill-editor', {
-                theme: 'snow'
-            });
-        }
-
-        function getQuillContent() {
-            return quill.root.innerHTML;
-        }
- </script>
 
 </body>
 

--- a/CMS/Components/App.razor
+++ b/CMS/Components/App.razor
@@ -13,6 +13,9 @@
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons"rel="stylesheet">
     <link href="/_content/PSC.Blazor.Components.MarkdownEditor/css/easymde.min.css" rel="stylesheet" />
 
+    <!-- Quill CSS -->
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+
     <HeadOutlet/>
 </head>
 
@@ -25,6 +28,22 @@
 
 <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/easymde.min.js"></script>
 <script src="/_content/PSC.Blazor.Components.MarkdownEditor/js/markdownEditor.js"></script>
+
+<!-- Quill JS -->
+<script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+ <script>
+        let quill;
+
+        function initQuillEditor() {
+            quill = new Quill('#quill-editor', {
+                theme: 'snow'
+            });
+        }
+
+        function getQuillContent() {
+            return quill.root.innerHTML;
+        }
+ </script>
 
 </body>
 

--- a/CMS/Components/Pages/ContentPages/CreateContent.razor
+++ b/CMS/Components/Pages/ContentPages/CreateContent.razor
@@ -35,22 +35,25 @@
 {
     <div>
         @RenderDynamicComponent(selectedInputFormPath, new Dictionary<string, object>
-        {
-            { "TemplateId", templateParameters["TemplateId"] },
-            { "WebPageId", templateParameters["WebPageId"] },
-            { "OnSubmit", EventCallback.Factory.Create<Dictionary<string, object>>(this, OnInputFormSubmit) }
-        })
+    {
+    { "TemplateId", templateParameters["TemplateId"] },
+    { "WebPageId", templateParameters["WebPageId"] },
+    { "OnSubmit", EventCallback.Factory.Create<Dictionary<string, object>>(this, OnInputFormSubmit) },
+    { "SaveBtnClicked", SaveBtnClicked }, // Pass the save button state
+    { "MultiPageMode", MultiPageMode } // Pass the MultiPageMode parameter
+    })
     </div>
 }
 
 @code {
-
-    // [SupplyParameterFromQuery]
-    // public int? WebPageId { get; set; } // Accept WebPageId from query parameters
-
-    [Parameter] 
+    [Parameter]
     [SupplyParameterFromQuery]
-    public int? WebPageId { get; set; } // Accept WebPageId as a parameter
+    public int? WebPageId { get; set; }
+
+    [Parameter]
+    public bool SaveBtnClicked { get; set; } // New parameter to handle save button click
+
+    [Parameter] public bool MultiPageMode { get; set; } = false; // Default to false
 
     private List<Template> templates = new List<Template>(); // Initialize with an empty list
     private string selectedTemplatePath;
@@ -67,7 +70,6 @@
         {
             templateParameters["WebPageId"] = WebPageId.Value;
         }
-
     }
 
     private void OnTemplateChanged(ChangeEventArgs e)
@@ -76,22 +78,19 @@
         var selectedTemplate = templates.FirstOrDefault(t => t.TemplatePath == selectedTemplatePath);
         if (selectedTemplate != null)
         {
-            selectedInputFormPath = selectedTemplate.InputFormPath; // Get the input form path
-                                                                    
+            selectedInputFormPath = selectedTemplate.InputFormPath;
+
             // Initialize parameters for the selected template
             templateParameters.Clear();
             templateParameters["TemplateId"] = selectedTemplate.TemplateId; // Pass the TemplateId
-
-            // Add WebPageId to parameters if available
             if (WebPageId.HasValue)
             {
                 templateParameters["WebPageId"] = WebPageId.Value;
             }
-
         }
         else
         {
-            selectedInputFormPath = null; // Clear input form if no template selected
+            selectedInputFormPath = null;
         }
     }
 

--- a/CMS/Components/Pages/HtmlTemplates/templates/Body/SingleImage.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/Body/SingleImage.razor
@@ -1,8 +1,15 @@
 ﻿@namespace Templates.Body
 
 <div class="image-container" style="background-color: @BackgroundColor; padding: 10px; box-shadow: @BoxShadow; text-align:@ImageAlignment;">
-    <img src="@ImageInput1" class="custom-image" style="width: @ImageWidth; height: @ImageHeight; border-radius: @($"{BorderRadius}px"); border: @($"{BorderWidth}px solid {BorderColor}");" />
+    <img src="@ImageInput1" class="custom-image" 
+    style="
+            width: @ImageWidth; 
+            height: @ImageHeight; 
+            border-radius: @(BorderRadius.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px");
+            border: @(BorderWidth.ToString(System.Globalization.CultureInfo.InvariantCulture) + "px solid " + BorderColor);
+" />
 </div>
+
 
 
 @code {
@@ -15,13 +22,13 @@
     [Parameter] public string ImageInput1 { get; set; }
 
     //user preferences to change the image as he wants
-    [Parameter] public string ImageWidth { get; set; } = "100%";
-    [Parameter] public string ImageHeight { get; set; } = "auto";
-    [Parameter] public decimal BorderWidth { get; set; } = 2;
-    [Parameter] public string BorderColor { get; set; } = "#cccccc";
-    [Parameter] public decimal BorderRadius { get; set; } = 0;
-    [Parameter] public string BoxShadow { get; set; } = "none";
-    [Parameter] public string BackgroundColor { get; set; } = "#ffffff";
-    [Parameter] public string Textcolor { get; set; } = "black";
-    [Parameter] public string ImageAlignment { get; set; } = "center";
+    [Parameter] public string ImageWidth { get; set; }
+    [Parameter] public string ImageHeight { get; set; }
+    [Parameter] public decimal BorderWidth { get; set; }
+    [Parameter] public string BorderColor { get; set; }
+    [Parameter] public decimal BorderRadius { get; set; }
+    [Parameter] public string BoxShadow { get; set; }
+    [Parameter] public string BackgroundColor { get; set; }
+    //[Parameter] public string Textcolor { get; set; } = "black";
+    [Parameter] public string ImageAlignment { get; set; }
 }

--- a/CMS/Components/Pages/HtmlTemplates/templates/Body/SingleTextField.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/Body/SingleTextField.razor
@@ -1,0 +1,21 @@
+﻿@namespace Templates.Body
+
+<div>
+    <!-- Markdown Preview -->
+    <div class="markdown-preview">
+        @((MarkupString)ConvertMarkdownToHtml(MarkdownContent))
+    </div>
+</div>
+
+@code {
+    [Parameter] public int TemplateId { get; set; }
+    [Parameter] public int WebPageId { get; set; }
+    [Parameter] public string ContentName { get; set; } = string.Empty;
+    [Parameter] public string MarkdownContent { get; set; } = string.Empty;
+
+    // Convert Markdown to HTML
+    private string ConvertMarkdownToHtml(string markdown)
+    {
+        return Markdig.Markdown.ToHtml(markdown); // Using the Markdig library for parsing
+    }
+}

--- a/CMS/Components/Pages/HtmlTemplates/templates/Body/SingleVideoInput.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/Body/SingleVideoInput.razor
@@ -1,21 +1,23 @@
 ﻿@namespace Templates.Body
 
 <!-- Video Preview Section -->
-<div class="video-container" style="margin-top: 20px; text-align:@VideoAlignment;">
+<div class="video-container" style="margin-top: 20px;">
     @if (IsYouTubeUrl(VideoUrl))
     {
-        <iframe width="560" style="display: block;"  height="315" src="@GetYouTubeEmbedUrl(VideoUrl)" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+        <iframe style="width: @VideoWidth; height: @VideoHeight; display: block; margin: 0 auto;"
+                src="@GetYouTubeEmbedUrl(VideoUrl)"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen>
+        </iframe>
     }
     else
     {
-        <video src="@VideoUrl" style="width: @VideoWidth; height: @VideoHeight;" controls>
+        <video src="@VideoUrl" style="width: @VideoWidth; height: @VideoHeight; display: block; margin: 0 auto;" controls>
             Your browser does not support the video tag.
         </video>
     }
 </div>
-
-
-
 
 @code {
     [Parameter] public int TemplateId { get; set; }
@@ -26,23 +28,24 @@
 
     // Video Properties
     [Parameter] public string VideoUrl { get; set; } = string.Empty;
-    [Parameter] public string VideoWidth { get; set; } = "100%";
-    [Parameter] public string VideoHeight { get; set; } = "auto";
-    [Parameter] public string VideoAlignment { get; set; } = "left";
+    [Parameter] public string VideoWidth { get; set; } = "100%";  // Use meaningful default values
+    [Parameter] public string VideoHeight { get; set; } = "315px"; // You can adjust height accordingly
+    [Parameter] public string VideoAlignment { get; set; } = "center";
 
-
-    // Method to construct a dictionary of video attributes
+    // Method to check if the video URL is from YouTube
     private bool IsYouTubeUrl(string url)
     {
         return url.Contains("youtube.com/watch") || url.Contains("youtu.be/");
     }
 
+    // Method to get YouTube embed URL
     private string GetYouTubeEmbedUrl(string url)
     {
         var videoId = ExtractYouTubeVideoId(url);
         return $"https://www.youtube.com/embed/{videoId}";
     }
 
+    // Method to extract YouTube video ID from URL
     private string ExtractYouTubeVideoId(string url)
     {
         var uri = new Uri(url);

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/Body1InputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/Body1InputForm.razor
@@ -35,7 +35,11 @@
         </div>
 
         <div style="margin-top: 10px;">
-            <button type="button" @onclick="SaveToDatabase">Save</button>
+            <button type="button" @onclick="PreviewImage">PreviewImage</button>
+            @if (!MultiPageMode) // Show button only if not in multi-page mode
+            {
+                <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            }
         </div>
     </form>
 </div>
@@ -55,6 +59,37 @@
     [Parameter] public string Backgroundcolor { get; set; } = "grey";
     [Parameter] public string Textcolor { get; set; } = "black";
     [Parameter] public EventCallback<Dictionary<string, object>> OnSubmit { get; set; }
+
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    protected override void OnParametersSet()
+    {
+        if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+        {
+            SaveToDatabase(); // Call the save method
+            hasSaved = true; // Set the flag to prevent further saves
+        }
+    }
+
+    private async Task PreviewImage()
+    {
+
+        // Mapping section to pass form values to a parent component or handler
+        var formValues = new Dictionary<string, object>
+        {
+            { "ContentName", ContentName },
+            { "ImageInput1", ImageInput1 },
+            { "CardTitle", CardTitle },
+            { "CardText1", CardText1 },
+            { "CardText2", CardText2 },
+            { "Backgroundcolor", Backgroundcolor },
+            { "Textcolor", Textcolor }
+        };
+
+        await OnSubmit.InvokeAsync(formValues);
+    }
 
     // Save all inputs to the database when the "Save" button is clicked
     private async Task SaveToDatabase()
@@ -95,23 +130,6 @@
             Console.WriteLine($"Error: {ex.InnerException?.Message}");
             throw;
         }
-
-        // Mapping section to pass form values to a parent component or handler
-        var formValues = new Dictionary<string, object>
-        {
-            { "ContentName", ContentName },
-            { "ImageInput1", ImageInput1 },
-            { "CardTitle", CardTitle },
-            { "CardText1", CardText1 },
-            { "CardText2", CardText2 },
-            { "Backgroundcolor", Backgroundcolor },
-            { "Textcolor", Textcolor }
-        };
-
-        await OnSubmit.InvokeAsync(formValues);
-
-        // Navigate to the contents page
-        //Done();
     }
 
     // Navigate to the contents page after saving

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/Body1InputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/Body1InputForm.razor
@@ -42,6 +42,16 @@
             }
         </div>
     </form>
+
+    <!-- Success message -->
+    @if (saveSuccessful)
+    {
+        <div class="alert alert-success" role="alert" style="margin-top: 20px;">
+            Content saved successfully!
+            <a href="/contents?webpageid=@WebPageId" class="alert-link">Click here to view all contents.</a>
+
+        </div>
+    }
 </div>
 
 @code {
@@ -63,6 +73,8 @@
     private bool hasSaved = false; // Flag to track if save has been executed
     [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
     [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    private bool saveSuccessful = false;  // New flag to show the success message
 
     protected override void OnParametersSet()
     {
@@ -130,6 +142,8 @@
             Console.WriteLine($"Error: {ex.InnerException?.Message}");
             throw;
         }
+
+        saveSuccessful = true;
     }
 
     // Navigate to the contents page after saving

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/DoubleInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/DoubleInputForm.razor
@@ -71,12 +71,26 @@
     [Parameter] public string Textcolor { get; set; } = "black";
     [Parameter] public EventCallback<Dictionary<string, object>> OnSubmit { get; set; }
 
+
     private string inputValue = string.Empty;
     private string inputValueContentName = string.Empty;
     private string inputValue1 = string.Empty;
     private string inputValue2 = string.Empty;
     private InputStep currentStep = InputStep.ContentNameInput;
     private string currentLabelText = string.Empty;
+
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    protected override void OnParametersSet()
+    {
+        if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+        {
+            SaveToDatabase(); // Call the save method
+            hasSaved = true; // Set the flag to prevent further saves
+        }
+    }
 
     protected override void OnInitialized()
     {

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/NavBarInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/NavBarInputForm.razor
@@ -97,6 +97,19 @@
     private InputStep currentStep = InputStep.ContentNameInput;
     private string currentLabelText = string.Empty;
 
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    // protected override void OnParametersSet()
+    // {
+    //     if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+    //     {
+    //         SaveToDatabase(); // Call the save method
+    //         hasSaved = true; // Set the flag to prevent further saves
+    //     }
+    // }
+
     protected override void OnInitialized()
     {
         currentLabelText = LabelText1;

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
@@ -73,18 +73,19 @@
     [Parameter] public int WebPageId { get; set; }
 
     [Parameter] public string ContentName { get; set; } = string.Empty;
+
     [Parameter] public string ImageInput1 { get; set; } = string.Empty;
     [Parameter] public EventCallback<Dictionary<string, object>> OnSubmit { get; set; }
 
-    [Parameter] public string ImageWidth { get; set; } = "100%";
-    [Parameter] public string ImageHeight { get; set; } = "auto";
-    [Parameter] public decimal BorderWidth { get; set; } = 2;
-    [Parameter] public string BorderColor { get; set; } = "#cccccc";
-    [Parameter] public decimal BorderRadius { get; set; } = 0;
-    [Parameter] public string BoxShadow { get; set; } = "none";
+    [Parameter] public string ImageWidth { get; set; } 
+    [Parameter] public string ImageHeight { get; set; }
+    [Parameter] public decimal BorderWidth { get; set; }
+    [Parameter] public string BorderColor { get; set; }
+    [Parameter] public decimal BorderRadius { get; set; }
+    [Parameter] public string BoxShadow { get; set; }
     [Parameter] public string BackgroundColor { get; set; }
-    [Parameter] public string Textcolor { get; set; }
-    [Parameter] public string ImageAlignment { get; set; } = "center";
+    //[Parameter] public string Textcolor { get; set; }
+    [Parameter] public string ImageAlignment { get; set; }
 
 
     // Save all inputs to the database when the "Save" button is clicked
@@ -103,7 +104,7 @@
             { "BorderRadius", BorderRadius },
             { "BoxShadow", BoxShadow },
             { "BackgroundColor", BackgroundColor },
-            { "Textcolor", Textcolor },
+            //{ "Textcolor", Textcolor },
             { "ImageAlignment", ImageAlignment }
         };
 

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
@@ -66,6 +66,16 @@
             }
         </div>
     </form>
+
+    <!-- Success message -->
+    @if (saveSuccessful)
+    {
+        <div class="alert alert-success" role="alert" style="margin-top: 20px;">
+            Content saved successfully!
+            <a href="/contents?webpageid=@WebPageId" class="alert-link">Click here to view all contents.</a>
+
+        </div>
+    }
 </div>
 
 @code {
@@ -93,6 +103,8 @@
     private bool hasSaved = false; // Flag to track if save has been executed
     [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
     [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    private bool saveSuccessful = false;  // New flag to show the success message
 
     protected override void OnParametersSet()
     {
@@ -170,17 +182,8 @@
             throw;
         }
 
-        // Mapping section to pass form values to a parent component or handler
-        // var formValues = new Dictionary<string, object>
-        // {
-        //     { "ContentName", ContentName },
-        //     { "ImageInput1", ImageInput1 },
-        // };
-
-        // await OnSubmit.InvokeAsync(formValues);
-
-        // Navigate to the contents page
-        //Done();
+        // Set the flag to true to show the success message
+        saveSuccessful = true;
     }
 
     // Navigate to the contents page after saving

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
@@ -60,7 +60,10 @@
 
         <div style="margin-top: 10px;">
             <button type="button" @onclick="PreviewImage">PreviewImage</button>
-            <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            @if (!MultiPageMode) // Show button only if not in multi-page mode
+            {
+                <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            }
         </div>
     </form>
 </div>
@@ -87,6 +90,20 @@
     //[Parameter] public string Textcolor { get; set; }
     [Parameter] public string ImageAlignment { get; set; }
 
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    // Other parameters as previously defined
+
+    protected override void OnParametersSet()
+    {
+        if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+        {
+            SaveToDatabase(); // Call the save method
+            hasSaved = true; // Set the flag to prevent further saves
+        }
+    }
 
     // Save all inputs to the database when the "Save" button is clicked
     private async Task PreviewImage()
@@ -109,9 +126,7 @@
         };
 
         await OnSubmit.InvokeAsync(formValues);
-
-        // Navigate to the contents page
-        //Done();
+        
     }
 
     // Save all inputs to the database when the "Save" button is clicked

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleImageInputForm.razor
@@ -94,8 +94,6 @@
     [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
     [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
 
-    // Other parameters as previously defined
-
     protected override void OnParametersSet()
     {
         if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleInputForm.razor
@@ -25,8 +25,23 @@
     [Parameter] public string Textcolor { get; set; } = "black"; // Add TextColor parameter
     [Parameter] public EventCallback<Dictionary<string, object>> OnSubmit { get; set; }
 
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    // protected override void OnParametersSet()
+    // {
+    //     if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+    //     {
+    //         SaveToDatabase(); // Call the save method
+    //         hasSaved = true; // Set the flag to prevent further saves
+    //     }
+    // }
+
     private string inputValue1 = string.Empty;
     private string inputValue2 = string.Empty;
+
+
 
     private async Task HandleSubmit()
     {

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleTextFieldInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleTextFieldInputForm.razor
@@ -39,6 +39,16 @@
             }
         </div>
     </form>
+
+    <!-- Success message -->
+    @if (saveSuccessful)
+    {
+        <div class="alert alert-success" role="alert" style="margin-top: 20px;">
+            Content saved successfully!
+            <a href="/contents?webpageid=@WebPageId" class="alert-link">Click here to view all contents.</a>
+
+        </div>
+    }
 </div>
 
 @code {
@@ -58,6 +68,8 @@
     private bool hasSaved = false; // Flag to track if save has been executed
     [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
     [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    private bool saveSuccessful = false;  // New flag to show the success message
 
     protected override void OnParametersSet()
     {
@@ -104,6 +116,7 @@
             throw;
         }
 
+        saveSuccessful = true;
         // // Navigate to the contents page after saving
         // Done();
     }

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleTextFieldInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleTextFieldInputForm.razor
@@ -1,0 +1,106 @@
+﻿@using CMS.Components.Pages.HtmlTemplates.templates
+@using CMS.Data
+@using CMS.Entities
+@using Microsoft.AspNetCore.Components
+@using Microsoft.EntityFrameworkCore
+@using System.Threading.Tasks
+
+@rendermode InteractiveServer
+
+@namespace Templates.InputForm
+<h3>Markdown Input Form</h3>
+
+<div>
+    <form>
+        <div>
+            <label>Content Name</label>
+            <input type="text" @bind="ContentName" placeholder="Enter name for content" class="form-control" />
+
+            <!-- Markdown Text Editor -->
+            <label>Markdown Content:</label>
+            <MarkdownEditor @bind-Value="MarkdownContent" SpellChecker="false">
+                <Toolbar>
+                    <MarkdownToolbarButton Action="MarkdownAction.Bold" Icon="fa fa-bold" Title="Bold" />
+                    <MarkdownToolbarButton Action="MarkdownAction.Italic" Icon="fa fa-italic" Title="Italic" />
+                    <MarkdownToolbarButton Action="MarkdownAction.Code" Icon="fa fa-code" Title="Code" />
+                    <MarkdownToolbarButton Action="MarkdownAction.Heading" Icon="fa fa-header" Title="Heading" />
+                    <MarkdownToolbarButton Action="MarkdownAction.UnorderedList" Icon="fa fa-list-ul" Title="Unordered List" />
+                    <MarkdownToolbarButton Action="MarkdownAction.OrderedList" Icon="fa fa-list-ol" Title="Ordered List" />
+                    <MarkdownToolbarButton Action="MarkdownAction.Table" Icon="fa fa-list-ol" Title="Ordered List" />
+
+                </Toolbar>
+            </MarkdownEditor>
+        </div>
+
+        <div style="margin-top: 10px;">
+            <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+        </div>
+    </form>
+</div>
+
+@code {
+    [Inject] private IDbContextFactory<ApplicationDbContext> DbFactory { get; set; } = default!;
+    [Inject] private NavigationManager NavigationManager { get; set; } = default!;
+
+    [Parameter] public int TemplateId { get; set; }
+    [Parameter] public int WebPageId { get; set; }
+
+    [Parameter] public string ContentName { get; set; } = string.Empty;
+    [Parameter] public string MarkdownContent { get; set; } = string.Empty;
+
+    [Parameter] public EventCallback<Dictionary<string, object>> OnSubmit { get; set; }
+
+    private string PreviewContent { get; set; } = string.Empty;
+
+    // Save all inputs to the database when the "Save" button is clicked
+    private async Task SaveToDatabase()
+    {
+        await using var context = DbFactory.CreateDbContext();
+
+        // Ensure WebPageId exists in the WebPages table
+        var webPageExists = await context.WebPages.AnyAsync(wp => wp.WebPageId == WebPageId);
+        if (!webPageExists)
+        {
+            throw new InvalidOperationException($"WebPageId {WebPageId} does not exist.");
+        }
+
+        // Save the markdown content as JSON
+        var content = new Content
+            {
+                ContentName = ContentName,
+                WebPageId = WebPageId,
+                TextInputsJson = Newtonsoft.Json.JsonConvert.SerializeObject(new
+                {
+                    MarkdownContent = MarkdownContent
+                }),
+                TemplateId = TemplateId
+            };
+
+        context.Contents.Add(content);
+        try
+        {
+            await context.SaveChangesAsync();
+        }
+        catch (DbUpdateException ex)
+        {
+            // Log detailed information for debugging
+            Console.WriteLine($"Error: {ex.InnerException?.Message}");
+            throw;
+        }
+
+        // Navigate to the contents page after saving
+        Done();
+    }
+
+    // Convert Markdown to HTML (for preview)
+    private string ConvertMarkdownToHtml(string markdown)
+    {
+        return Markdig.Markdown.ToHtml(markdown); // Using Markdig for Markdown to HTML conversion
+    }
+
+    // Navigate to the contents page after saving
+    private void Done()
+    {
+        NavigationManager.NavigateTo($"/contents?webpageid={WebPageId}");
+    }
+}

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleTextFieldInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleTextFieldInputForm.razor
@@ -33,7 +33,10 @@
         </div>
 
         <div style="margin-top: 10px;">
-            <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            @if (!MultiPageMode) // Show button only if not in multi-page mode
+            {
+                <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            }
         </div>
     </form>
 </div>
@@ -51,6 +54,19 @@
     [Parameter] public EventCallback<Dictionary<string, object>> OnSubmit { get; set; }
 
     private string PreviewContent { get; set; } = string.Empty;
+
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    protected override void OnParametersSet()
+    {
+        if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+        {
+            SaveToDatabase(); // Call the save method
+            hasSaved = true; // Set the flag to prevent further saves
+        }
+    }
 
     // Save all inputs to the database when the "Save" button is clicked
     private async Task SaveToDatabase()
@@ -88,8 +104,8 @@
             throw;
         }
 
-        // Navigate to the contents page after saving
-        Done();
+        // // Navigate to the contents page after saving
+        // Done();
     }
 
     // Convert Markdown to HTML (for preview)

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleVideoInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleVideoInputForm.razor
@@ -39,7 +39,10 @@
 
         <div style="margin-top: 10px;">
             <button type="button" @onclick="PreviewImage">PreviewImage</button>
-            <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            @if (!MultiPageMode) // Show button only if not in multi-page mode
+            {
+                <button type="button" @onclick="SaveToDatabase">Save To Database</button>
+            }
         </div>
     </form>
 </div>
@@ -59,6 +62,19 @@
     [Parameter] public string VideoWidth { get; set; } = "100%";  // Use meaningful default values
     [Parameter] public string VideoHeight { get; set; } = "315px"; // You can adjust height accordingly
     [Parameter] public string VideoAlignment { get; set; } = "center";
+
+    private bool hasSaved = false; // Flag to track if save has been executed
+    [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
+    [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    protected override void OnParametersSet()
+    {
+        if (SaveBtnClicked && !hasSaved) // Check if SaveBtnClicked and save hasn't been executed yet
+        {
+            SaveToDatabase(); // Call the save method
+            hasSaved = true; // Set the flag to prevent further saves
+        }
+    }
 
 
     // Save all inputs to the database when the "Save" button is clicked

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleVideoInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleVideoInputForm.razor
@@ -45,6 +45,15 @@
             }
         </div>
     </form>
+
+    <!-- Success message -->
+    @if (saveSuccessful)
+    {
+        <div class="alert alert-success" role="alert" style="margin-top: 20px;">
+            Content saved successfully!
+            <a href="/contents?webpageid=@WebPageId" class="alert-link">Click here to view all contents.</a>
+        </div>
+    }
 </div>
 
 @code {
@@ -66,6 +75,8 @@
     private bool hasSaved = false; // Flag to track if save has been executed
     [Parameter] public bool SaveBtnClicked { get; set; } // New parameter to handle save button state
     [Parameter] public bool MultiPageMode { get; set; } // Receive MultiPageMode parameter
+
+    private bool saveSuccessful = false;  // New flag to show the success message
 
     protected override void OnParametersSet()
     {
@@ -134,17 +145,7 @@
             throw;
         }
 
-        // Mapping section to pass form values to a parent component or handler
-        // var formValues = new Dictionary<string, object>
-        // {
-        //     { "ContentName", ContentName },
-        //     { "ImageInput1", ImageInput1 },
-        // };
-
-        // await OnSubmit.InvokeAsync(formValues);
-
-        // Navigate to the contents page
-        //Done();
+        saveSuccessful = true;
     }
 
     // Navigate to the contents page after saving

--- a/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleVideoInputForm.razor
+++ b/CMS/Components/Pages/HtmlTemplates/templates/InputForm/SingleVideoInputForm.razor
@@ -56,9 +56,9 @@
 
     // Video Properties
     [Parameter] public string VideoUrl { get; set; } = string.Empty;
-    [Parameter] public string VideoWidth { get; set; } = "100%";
-    [Parameter] public string VideoHeight { get; set; } = "auto";
-    [Parameter] public string VideoAlignment { get; set; } = "left";
+    [Parameter] public string VideoWidth { get; set; } = "100%";  // Use meaningful default values
+    [Parameter] public string VideoHeight { get; set; } = "315px"; // You can adjust height accordingly
+    [Parameter] public string VideoAlignment { get; set; } = "center";
 
 
     // Save all inputs to the database when the "Save" button is clicked

--- a/CMS/Components/Pages/WebPages/AddMultipleContentsPage.razor
+++ b/CMS/Components/Pages/WebPages/AddMultipleContentsPage.razor
@@ -19,7 +19,7 @@ else
     <!-- Header Section -->
     <header class="header-section">
         <p>HEADER</p>
-        <htmltemplates.templates.CreateContent WebPageId="@webpage.WebPageId"></htmltemplates.templates.CreateContent>
+        <htmltemplates.templates.CreateContent WebPageId="@webpage.WebPageId" SaveBtnClicked="saveBtnClicked" MultiPageMode="multipagemode"></htmltemplates.templates.CreateContent>
     </header>
 
     <!-- Main Body Sections -->
@@ -28,17 +28,19 @@ else
         {
             <div class="main-body-section">
                 <p>BODY</p>
-                <htmltemplates.templates.CreateContent WebPageId="@webpage.WebPageId"></htmltemplates.templates.CreateContent>
+                <htmltemplates.templates.CreateContent WebPageId="@webpage.WebPageId" SaveBtnClicked="saveBtnClicked" MultiPageMode="multipagemode"></htmltemplates.templates.CreateContent>
             </div>
         }
         <button @onclick="AddNewContent" class="add-button">Add New Content</button>
     </main>
-
     <!-- Footer Section -->
     <footer class="footer-section">
         <p>FOOTER</p>
-        <htmltemplates.templates.CreateContent WebPageId="@webpage.WebPageId"></htmltemplates.templates.CreateContent>
+        <htmltemplates.templates.CreateContent WebPageId="@webpage.WebPageId" SaveBtnClicked="saveBtnClicked" MultiPageMode="multipagemode"></htmltemplates.templates.CreateContent>
     </footer>
+
+    <!-- Save Button -->
+    <button @onclick="SaveAllContents" class="save-button">Save All Contents</button>
 }
 
 @code {
@@ -46,6 +48,9 @@ else
     WebPage? webpage;
 
     private List<int> contentIndexes = new List<int>();
+    private bool saveBtnClicked = false; // Track if save button has been clicked
+    private bool multipagemode = true;
+
 
     [SupplyParameterFromQuery]
     public int WebPageId { get; set; }
@@ -63,10 +68,15 @@ else
 
     private void AddNewContent()
     {
-        // Add a new index to the list to render an additional CreateContent component
         contentIndexes.Add(contentIndexes.Count);
     }
+
+    private void SaveAllContents()
+    {
+        saveBtnClicked = true; // Set to true when save button is clicked
+    }
 }
+
 
 <!-- Add your CSS here or in a separate stylesheet -->
 <style>

--- a/CMS/Components/Pages/WebPages/AddMultipleContentsPage.razor
+++ b/CMS/Components/Pages/WebPages/AddMultipleContentsPage.razor
@@ -41,6 +41,15 @@ else
 
     <!-- Save Button -->
     <button @onclick="SaveAllContents" class="save-button">Save All Contents</button>
+
+    <!-- Success Message -->
+    @if (saveSuccessful)
+    {
+        <div class="alert alert-success" role="alert" style="margin-top: 20px;">
+            All contents have been saved successfully!
+            <a href="/contents?webpageid=@WebPageId" class="alert-link">Click here to view the contents</a> | <a href="/webpages/previewpage/@WebPageId" class="alert-link">Click here to preview the webpage</a>
+        </div>
+    }
 }
 
 @code {
@@ -50,7 +59,7 @@ else
     private List<int> contentIndexes = new List<int>();
     private bool saveBtnClicked = false; // Track if save button has been clicked
     private bool multipagemode = true;
-
+    private bool saveSuccessful = false; // New flag to show success message
 
     [SupplyParameterFromQuery]
     public int WebPageId { get; set; }
@@ -74,6 +83,12 @@ else
     private void SaveAllContents()
     {
         saveBtnClicked = true; // Set to true when save button is clicked
+
+        // Simulate saving all contents to the database
+        // Add your actual save logic here, for now we assume the save is successful.
+
+        // After save is done, set saveSuccessful to true to display the message
+        saveSuccessful = true;
     }
 }
 
@@ -108,5 +123,18 @@ else
 
     .footer-section {
         background-color: #f4f4f4;
+    }
+
+    .alert-success {
+        color: #155724;
+        background-color: #d4edda;
+        border-color: #c3e6cb;
+        padding: 10px;
+        border-radius: 5px;
+    }
+
+    .alert-link {
+        color: #155724;
+        font-weight: bold;
     }
 </style>

--- a/CMS/Seed/SeedData.cs
+++ b/CMS/Seed/SeedData.cs
@@ -189,7 +189,14 @@ namespace CMS.Seed
                     TemplateType = "BodySingleVideo",
                     TemplatePath = "Templates.Body.SingleVideoInput",
                     InputFormPath = "Templates.InputForm.SingleVideoInputForm"
+                },
+                new Template
+                {
+                    TemplateType = "BodySingleTextField",
+                    TemplatePath = "Templates.Body.SingleTextField",
+                    InputFormPath = "Templates.InputForm.SingleTextFieldInputForm"
                 }
+
             };
 
             return list;

--- a/CMS/Seed/SeedWithoutWebsites.cs
+++ b/CMS/Seed/SeedWithoutWebsites.cs
@@ -92,6 +92,12 @@ namespace CMS.Seed
                     TemplateType = "BodySingleVideo",
                     TemplatePath = "Templates.Body.SingleVideoInput",
                     InputFormPath = "Templates.InputForm.SingleVideoInputForm"
+                },
+                   new Template
+                {
+                    TemplateType = "BodySingleTextField",
+                    TemplatePath = "Templates.Body.SingleTextField",
+                    InputFormPath = "Templates.InputForm.SingleTextFieldInputForm"
                 }
             };
             return list;


### PR DESCRIPTION
[Created]: a simple template and inputform to add text using markdown
[Created]: a button to save all contents at same time, in create multiple contents page, if you only create a single content then save to database button will be shown.
[Created]: a message if we have saved to database and give the user alternative to go to preview webpage or content
[Edit]: added a row for the singletextinput template in seed files
[Edit]: added some parameters in every template so it would be compitable with using the save all contents button
[edit]: made some changes in single image and video input templates, since some part i noticed didn't work to save/show such as border/border radius or something smililar. 

images: 

save button and messages
![image](https://github.com/user-attachments/assets/43cc0715-4a2c-4421-a281-0617b2d308ac)
![image](https://github.com/user-attachments/assets/e443fe1a-fe1a-48e5-92b8-4229fc15c1e0)
![image](https://github.com/user-attachments/assets/6d688eb8-cd74-4aae-a898-7db854e62c72)

text editor :
![image](https://github.com/user-attachments/assets/fcb192e9-72ec-4dab-8af0-f101402e05b4)

result of adding evering and is shown in preview:
![image](https://github.com/user-attachments/assets/ecd44977-0e33-45c0-82ba-cadb67177045)

