### PR TITLE
Component to render a list of webpages connected to a website with additional info / functionality

### DIFF
--- a/CMS/CMS.csproj
+++ b/CMS/CMS.csproj
@@ -23,12 +23,17 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Components\BlazorComponents\ConnectedWebPagesInfo.razor.css" />
     <None Remove="Components\BlazorComponents\Footer.css" />
     <None Remove="Components\Pages\WebSitePages\Index.css" />
   </ItemGroup>
 
   <ItemGroup>
     <Compile Remove="Services\GetCurrentUserIdService.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Components\BlazorComponents\ConnectedWebPagesInfo.razor.css" />
   </ItemGroup>
 
 

--- a/CMS/Components/BlazorComponents/ConnectedWebPagesInfo.razor
+++ b/CMS/Components/BlazorComponents/ConnectedWebPagesInfo.razor
@@ -1,0 +1,49 @@
+﻿@using CMS.Services
+@inject NavigationManager NavigationManager
+@inject IDbContextFactory<CMS.Data.ApplicationDbContext> DbFactory
+
+@if (WebPages?.Any() == true)
+{
+    <div class="webpageinfo">
+        <p align="center">Tillhörande webbsidor</p>
+        <div class="grid">
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>Id</th>
+                        <th>Rubrik</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var webpage in WebPages)
+                    {
+                        <tr>
+                            <td>@webpage.WebPageId</td>
+                            <td>
+                                <a href="/webpages/details?webpageid=@webpage.WebPageId">
+                                    @webpage.Title
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    </div>
+}
+
+@code {
+    [Parameter]
+    public int WebSiteId { get; set; }
+
+    List<WebPage>? WebPages = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        var context = await DbFactory.CreateDbContextAsync();
+
+        WebPages = await context.WebPages
+            .Where(wp => wp.WebSiteId == WebSiteId)
+            .ToListAsync();
+    }
+}

--- a/CMS/Components/BlazorComponents/ConnectedWebPagesInfo.razor.css
+++ b/CMS/Components/BlazorComponents/ConnectedWebPagesInfo.razor.css
@@ -1,0 +1,45 @@
+﻿﻿ /*Komponenten är lika bred som dess vidaste komponent*/
+.webpageinfo {
+	background-color: #f2f2f2;
+	padding: 10px;
+	border-radius: 5px;
+	display: flex;
+	flex-direction: column;
+	width: max-content;
+	border: 2px solid black;
+}
+
+.webpageinfo > * {
+	flex-shrink: 0;
+}
+
+.grid {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 10px;
+}
+
+.grid-item {
+	flex: 1 1 calc(50% - 5px);
+	max-width: calc(50% - 5px);
+}
+
+::deep tr {
+	height: 1.8rem;
+}
+
+::deep tr:nth-child(odd) {
+	background-color: #f2f2f2;
+}
+
+::deep tr:nth-child(even) {
+	background-color: white;
+}
+
+.webpageinfo p {
+	background-color: #007bff;
+	color: white;
+	padding: 5px;
+	margin-bottom: 10px;
+	border-radius: 10px;
+}

--- a/CMS/Components/Pages/WebSitePages/Details.razor
+++ b/CMS/Components/Pages/WebSitePages/Details.razor
@@ -29,12 +29,14 @@
         <dd class="col-sm-10">@website.CreationDate</dd>
         <dt class="col-sm-2">Senast uppdaterad</dt>
         <dd class="col-sm-10">@website.LastUpdated</dd>
+        <dt class="col-sm-2">Startsida</dt>
+        <dd class="col-sm-10">@landingPageTitle</dd>
         <AuthorizeView Roles="Admin">
             <dt class="col-sm-2">Användar Id</dt>
             <dd class="col-sm-10">@website.UserId</dd>
         </AuthorizeView>
     </dl>
-
+        <ConnectedWebPagesInfo WebSiteId="@WebSiteId" />
     <p>Denna sida har besökts @VisitCount gånger.</p>
     
     <div>
@@ -47,6 +49,56 @@
 </div>
 
 @code {
+    WebSite? website;
+    private int VisitCount { get; set; }
+    private string CurrentPageUrl => NavigationManager.Uri;
+    private string? landingPageTitle;
+
+    [SupplyParameterFromQuery]
+    public int WebSiteId { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        using var context = DbFactory.CreateDbContext();
+        website = await context.WebSites.FirstOrDefaultAsync(m => m.WebSiteId == WebSiteId);
+
+        if (website?.LandingPage != null)
+        {
+            var landingPage = await context.WebPages
+                .FirstOrDefaultAsync(wp => wp.WebPageId == website.LandingPage);
+
+            landingPageTitle = landingPage?.Title;
+        }
+        else if (website?.LandingPage is null)
+        {
+            var hasWebPages = await context.WebPages
+                 .AnyAsync(wp => wp.WebSiteId == WebSiteId);
+
+            if (hasWebPages)
+            {
+                landingPageTitle = "Webbsiten har ingen startsida vald";
+            }
+            else
+            {
+                landingPageTitle = "Webbsiten har inga webbsidor";
+            }
+        }
+
+        if (website is null)
+        {
+            NavigationManager.NavigateTo("notfound");
+        }
+        else
+        {
+            // Increment the visit count for this specific page
+            await VisitorCounterService.IncrementPageVisitAsync(WebSiteId, CurrentPageUrl);
+
+            // Get the updated visit count for this page
+            VisitCount = await VisitorCounterService.GetPageVisitCountAsync(WebSiteId, CurrentPageUrl);
+        }
+    }
+}
+@* @code {
     WebSite? website;
     private int VisitCount { get; set; }
     private string CurrentPageUrl => NavigationManager.Uri;
@@ -72,5 +124,5 @@
             VisitCount = await VisitorCounterService.GetPageVisitCountAsync(WebSiteId, CurrentPageUrl);
         }
     }
-}
+} *@
 

--- a/CMS/Components/Pages/WebSitePages/Details.razor
+++ b/CMS/Components/Pages/WebSitePages/Details.razor
@@ -12,7 +12,7 @@
 <h1>Detaljer</h1>
 
 <div>
-    <h4>WebSida</h4>
+    <h4>WebbSida</h4>
     <hr />
     @if (website is null)
     {

--- a/CMS/Components/Pages/WebSitePages/Details.razor
+++ b/CMS/Components/Pages/WebSitePages/Details.razor
@@ -2,10 +2,9 @@
 @attribute [Authorize]
 
 @using CMS.Entities
-@using CMS.Services
 @inject IDbContextFactory<CMS.Data.ApplicationDbContext> DbFactory
 @inject NavigationManager NavigationManager
-@inject VisitorCounterService VisitorCounterService
+
 
 <PageTitle>Detaljer</PageTitle>
 
@@ -88,41 +87,7 @@
         {
             NavigationManager.NavigateTo("notfound");
         }
-        else
-        {
-            // Increment the visit count for this specific page
-            await VisitorCounterService.IncrementPageVisitAsync(WebSiteId, CurrentPageUrl);
-
-            // Get the updated visit count for this page
-            VisitCount = await VisitorCounterService.GetPageVisitCountAsync(WebSiteId, CurrentPageUrl);
-        }
     }
 }
-@* @code {
-    WebSite? website;
-    private int VisitCount { get; set; }
-    private string CurrentPageUrl => NavigationManager.Uri;
 
-    [SupplyParameterFromQuery]
-    public int WebSiteId { get; set; }
-
-    protected override async Task OnInitializedAsync()
-    {
-        using var context = DbFactory.CreateDbContext();
-        website = await context.WebSites.FirstOrDefaultAsync(m => m.WebSiteId == WebSiteId);
-
-        if (website is null)
-        {
-            NavigationManager.NavigateTo("notfound");
-        }
-        else
-        {
-            // Increment the visit count for this specific page
-            await VisitorCounterService.IncrementPageVisitAsync(WebSiteId, CurrentPageUrl);
-
-            // Get the updated visit count for this page
-            VisitCount = await VisitorCounterService.GetPageVisitCountAsync(WebSiteId, CurrentPageUrl);
-        }
-    }
-} *@
 


### PR DESCRIPTION
Component is currently used in "/websites/details"

**Added :** ConnectedWebPagesInfo component that fetch the webpages (if any) connected to a website.
**Fixed :** /websites/details did not have proper support for 'LandingPage'
**Moved :** WebSiteVisitorCounter to BlazorComponent folder.
**Changed :** Removed useless stuff from navmeny when logged in, need input on that

List items of connected webpages are an Id and a webpage name. (Id is for during development).
The name is a link that takes the user to "/webpages/details" of that webpage if clicked.
The list including "Tillhörande webbsidor"(centered) is flexible and will adjust to the list item using most letters.
Or at minumum be the width of "Tillhörande webbsidor".

**/websites/details specific changes:**
_"Startsida"_ got functionality to check the 3 states:

- 'LandingPage' is set (Om Oss in the picture)
- Website has no webpages yet
- Website contains webpage(s) but no 'LandingPage' is set

![image](https://github.com/user-attachments/assets/634630b5-0449-4c26-990c-e3139ec575f2)
